### PR TITLE
Add cycle method for active connections

### DIFF
--- a/fluster/__init__.py
+++ b/fluster/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.5'
+__version__ = '0.1.0'
 
 from .utils import round_controlled
 from .cluster import FlusterCluster

--- a/fluster/__init__.py
+++ b/fluster/__init__.py
@@ -1,5 +1,6 @@
 __version__ = '0.0.5'
 
+from .utils import round_controlled
 from .cluster import FlusterCluster
 from .exceptions import ClusterEmptyError
 

--- a/fluster/cluster.py
+++ b/fluster/cluster.py
@@ -59,15 +59,13 @@ class FlusterCluster(object):
         if len(self.active_clients) == 0:
             raise ClusterEmptyError('All clients are down.')
 
-        # always return something
-        nxt = None
-        while nxt is None:
-            nxt = self._next_helper()
+        # refresh connections if they're back up
+        self._prune_penalty_box()
 
-        self._ticks += 1
-        if self._ticks == self._tick_interval:
-            self._tick()
-        return nxt
+        # return the first client that's active
+        for client in self.clients:
+            if client in self.active_clients:
+                return client
 
     def _tick(self):
         """Called every self._tick_interval iterations to do maintenance work."""
@@ -77,15 +75,6 @@ class FlusterCluster(object):
     def next(self):
         """Python 2/3 compatibility."""
         return self.__next__()
-
-    def _next_helper(self):
-        """Helper that only returns an active connection.
-        """
-        curr = next(self.clients)
-
-        # only return active connections
-        if curr in self.active_clients:
-            return curr
 
     def _sort_clients(self):
         """Make sure clients are sorted consistently for consistent results."""

--- a/fluster/cluster.py
+++ b/fluster/cluster.py
@@ -40,8 +40,8 @@ class FlusterCluster(object):
         self.active_clients = self._prep_clients(clients)
         self.initial_clients = {c.pool_id: c for c in clients}
         self._sort_clients()
-        # maintain cycle trackers
-        self._requesters = {}
+        # maintain separate cycle trackers for each requester
+        self._requester_cycles = {}
 
     def _sort_clients(self):
         """Make sure clients are sorted consistently for consistent results."""
@@ -133,27 +133,23 @@ class FlusterCluster(object):
             return self.active_clients[pos]
 
     def get_client_cycle(self, requester, cycles=1):
-        """Yield clients, maintaining a pointer to the last used client for each requester.
+        """Yield clients, maintaining separate cycles for each requester.
 
-        Will not generate the same client more than `cycles` times per use of the function.
-
-        Also handles down nodes.
+        Will not generate the same client more than `cycles` times,
+        per use of the function. Also handles down nodes.
 
         :param requester: Hashable key for each requesting object.
         :param cycles: Max times to return each client per call.
         """
-        if requester not in self._requesters:
-            # create a cycle for it
-            print("Making a cycle for this requester")
-            self._requesters[requester] = cycle(self.initial_clients.values())
+        if requester not in self._requester_cycles:
+            self._requester_cycles[requester] = cycle(self.initial_clients.values())
 
         self._prune_penalty_box()
 
         if len(self.active_clients) == 0:
             raise ClusterEmptyError('All clients are down.')
 
-        # yield clients if they are in the active clients list
-        conn_cycle = self._requesters[requester]
+        conn_cycle = self._requester_cycles[requester]
         placemarker = None
         rounds = 0
         for next_client in conn_cycle:
@@ -168,7 +164,6 @@ class FlusterCluster(object):
 
             if next_client in self.active_clients:
                 yield next_client
-
 
     def penalize_client(self, client):
         """Place client in the penalty box manually.

--- a/fluster/cluster.py
+++ b/fluster/cluster.py
@@ -131,12 +131,10 @@ class FlusterCluster(object):
             pos = hashed % len(self.active_clients)
             return self.active_clients[pos]
 
-    def get_active_client_cycle(self, rounds=1):
+    def get_active_client_cycle(self):
         """Create an ActiveClientCycle using this cluster.
-
-        :param rounds: max number of times to see each client per call to __iter__
         """
-        return ActiveClientCycle(self, rounds=rounds)
+        return ActiveClientCycle(self)
 
     def _penalize_client(self, client):
         """Place client in the penalty box.

--- a/fluster/cluster.py
+++ b/fluster/cluster.py
@@ -44,9 +44,6 @@ class FlusterCluster(object):
         self.initial_clients = {c.pool_id: c for c in clients}
         self.clients = cycle(self.initial_clients.values())
         self._sort_clients()
-        # maintenance work is done each "tick" when iterating
-        self._tick_interval = 2 * len(clients)
-        self._ticks = 0
 
     def __iter__(self):
         """Updates active clients each time it's iterated through."""
@@ -66,11 +63,6 @@ class FlusterCluster(object):
         for client in self.clients:
             if client in self.active_clients:
                 return client
-
-    def _tick(self):
-        """Called every self._tick_interval iterations to do maintenance work."""
-        self._prune_penalty_box()
-        self._ticks = 0
 
     def next(self):
         """Python 2/3 compatibility."""

--- a/fluster/cluster.py
+++ b/fluster/cluster.py
@@ -41,8 +41,6 @@ class FlusterCluster(object):
         self.active_clients = self._prep_clients(clients)
         self.initial_clients = {c.pool_id: c for c in clients}
         self._sort_clients()
-        # maintain separate cycle trackers for each requester
-        #self._requester_cycles = {}
 
     def _sort_clients(self):
         """Make sure clients are sorted consistently for consistent results."""
@@ -134,16 +132,11 @@ class FlusterCluster(object):
             return self.active_clients[pos]
 
     def get_active_client_cycle(self, rounds=1):
-        """Yield clients, maintaining separate cycles for each requester.
+        """Create an ActiveClientCycle using this cluster.
 
-        Will not generate the same client more than `cycles` times,
-        per use of the function. Also handles down nodes.
-
-        :param requester: Hashable key for each requesting object.
-        :param cycles: Max times to return each client per call.
+        :param rounds: max number of times to see each client per call to __iter__
         """
         return ActiveClientCycle(self, rounds=rounds)
-
 
     def _penalize_client(self, client):
         """Place client in the penalty box.

--- a/fluster/penalty_box.py
+++ b/fluster/penalty_box.py
@@ -35,14 +35,14 @@ class PenaltyBox(object):
         now = time.time()
         while self._clients and self._clients[0][0] < now:
             _, (client, last_wait) = heapq.heappop(self._clients)
-            s = time.time()
+            connect_start = time.time()
             try:
                 client.echo('test')  # reconnected if this succeeds.
                 self._client_ids.remove(client.pool_id)
                 yield client
             except (ConnectionError, TimeoutError):
-                timer = time.time() - s
+                timer = time.time() - connect_start
                 wait = min(int(last_wait * self._multiplier), self._max_wait)
                 heapq.heappush(self._clients,
                                (time.time() + wait, (client, wait)))
-                log.info('%r is still down after %s seconds. Retrying in %ss.', client, timer, wait)
+                log.info('%r is still down after a %s second attempt to connect. Retrying in %ss.', client, timer, wait)

--- a/fluster/penalty_box.py
+++ b/fluster/penalty_box.py
@@ -35,12 +35,14 @@ class PenaltyBox(object):
         now = time.time()
         while self._clients and self._clients[0][0] < now:
             _, (client, last_wait) = heapq.heappop(self._clients)
+            s = time.time()
             try:
                 client.echo('test')  # reconnected if this succeeds.
                 self._client_ids.remove(client.pool_id)
                 yield client
             except (ConnectionError, TimeoutError):
+                timer = time.time() - s
                 wait = min(int(last_wait * self._multiplier), self._max_wait)
                 heapq.heappush(self._clients,
                                (time.time() + wait, (client, wait)))
-                log.info('%r is still down. Retrying in %ss.', client, wait)
+                log.info('%r is still down after %s seconds. Retrying in %ss.', client, timer, wait)

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -1,8 +1,3 @@
-from itertools import cycle
-
-from .exceptions import ClusterEmptyError
-
-
 def round_controlled(cycled_iterable, rounds=1):
     """Raise StopIteration after <rounds> passes through a cycled iterable."""
     round_start = None
@@ -18,49 +13,3 @@ def round_controlled(cycled_iterable, rounds=1):
             raise StopIteration
 
         yield item
-
-
-class ActiveClientCycle(object):
-    """Only returns active clients.
-
-    Useful when you need to evenly cycle through active connections, skipping
-    dead ones.
-
-    Each user of the class should instantiate a separate object to correctly track
-    the last requested client for that user.
-    """
-    def __init__(self, cluster):
-        self.cluster = cluster
-        self.clients = cycle(cluster.initial_clients.values())
-
-    def __iter__(self):
-        """Restarts the `rounds` tracker, and updates active clients."""
-        self.cluster._prune_penalty_box()
-
-        return self
-
-    def __next__(self):
-        """Always returns a client, or raises an Exception if none are available."""
-        # raise Exception if no clients are available
-        if len(self.cluster.active_clients) == 0:
-            raise ClusterEmptyError('All clients are down.')
-
-        # always return something
-        nxt = None
-        while nxt is None:
-            nxt = self._next_helper()
-
-        return nxt
-
-    def next(self):
-        """Python 2/3 compatibility."""
-        return self.__next__()
-
-    def _next_helper(self):
-        """Helper that only returns an active connection.
-        """
-        curr = next(self.clients)
-
-        # only return active connections
-        if curr in self.cluster.active_clients:
-            return curr

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -1,0 +1,61 @@
+from itertools import cycle
+
+from .exceptions import ClusterEmptyError
+
+
+class ActiveClientCycle(object):
+    """Tracks last returned client, will not iterate more than `rounds` times.
+
+    Useful when you need to evenly cycle through active connections to check
+    each once for work.
+
+    Each user of the class should instantiate a separate object to correctly track
+    the last requested client for that requester.
+    """
+    def __init__(self, cluster, rounds=1):
+        self.cluster = cluster
+        self.round_limit = rounds
+        self.clients = cycle(cluster.initial_clients.values())
+
+        # initialize pointers and trackers
+        self.current_client = None
+        self.round_start = None
+        self.rounds_completed = 0
+
+    def __iter__(self):
+        """Restarts the `rounds` tracker, and updates active clients."""
+        self.round_start = None
+        self.rounds_completed = 0
+
+        self.cluster._prune_penalty_box()  # XX TODO make public
+
+        if len(self.cluster.active_clients) == 0:
+            raise ClusterEmptyError('All clients are down.')
+
+        return self
+
+    def __next__(self):
+        nxt = None
+        while nxt is None:
+            nxt = self._next_helper()
+
+        return nxt
+
+    def _next_helper(self):
+        """Returns an active connection, unless this iterable has already cycled
+        through too many times.
+        """
+        curr = next(self.clients)
+
+        # manage round counting
+        if not self.round_start:
+            self.round_start = curr
+        elif self.round_start == curr:
+            self.rounds_completed += 1
+
+        if self.rounds_completed >= self.round_limit:
+            raise StopIteration
+
+        # check active clients
+        if curr in self.cluster.active_clients:
+            return curr

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -3,13 +3,13 @@ from itertools import cycle
 from .exceptions import ClusterEmptyError
 
 
-def round_controlled(iterable, rounds=1):
-    """Raise StopIteration after <rounds> passes through iterable."""
+def round_controlled(cycled_iterable, rounds=1):
+    """Raise StopIteration after <rounds> passes through a cycled iterable."""
     round_start = None
     rounds_completed = 0
 
-    for item in iterable:
-        if not round_start:
+    for item in cycled_iterable:
+        if round_start is None:
             round_start = item
         elif item == round_start:
             rounds_completed += 1
@@ -21,7 +21,7 @@ def round_controlled(iterable, rounds=1):
 
 
 class ActiveClientCycle(object):
-    """Tracks last returned client, will not iterate more than `rounds` times.
+    """Only returns active clients.
 
     Useful when you need to evenly cycle through active connections, skipping
     dead ones.
@@ -53,11 +53,11 @@ class ActiveClientCycle(object):
         return nxt
 
     def next(self):
+        """Python 2/3 compatibility."""
         return self.__next__()
 
     def _next_helper(self):
-        """Returns an active connection, unless this iterable has already cycled
-        through too many times.
+        """Helper that only returns an active connection.
         """
         curr = next(self.clients)
 

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -43,6 +43,9 @@ class ActiveClientCycle(object):
 
         return nxt
 
+    def next(self):
+        return self.__next__()
+
     def _next_helper(self):
         """Returns an active connection, unless this iterable has already cycled
         through too many times.

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -29,12 +29,13 @@ class ActiveClientCycle(object):
 
         self.cluster._prune_penalty_box()  # XX TODO make public
 
-        if len(self.cluster.active_clients) == 0:
-            raise ClusterEmptyError('All clients are down.')
-
         return self
 
     def __next__(self):
+        """Always returns a client, or raises an Exception if none are available."""
+        if len(self.cluster.active_clients) == 0:
+            raise ClusterEmptyError('All clients are down.')
+
         nxt = None
         while nxt is None:
             nxt = self._next_helper()

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -3,6 +3,23 @@ from itertools import cycle
 from .exceptions import ClusterEmptyError
 
 
+def round_controlled(iterable, rounds=1):
+    """Raise StopIteration after <rounds> passes through iterable."""
+    round_start = None
+    rounds_completed = 0
+
+    for item in iterable:
+        if not round_start:
+            round_start = item
+        elif item == round_start:
+            rounds_completed += 1
+
+        if rounds_completed == rounds:
+            raise StopIteration
+
+        yield item
+
+
 class ActiveClientCycle(object):
     """Tracks last returned client, will not iterate more than `rounds` times.
 

--- a/fluster/utils.py
+++ b/fluster/utils.py
@@ -17,15 +17,15 @@ class ActiveClientCycle(object):
         self.round_limit = rounds
         self.clients = cycle(cluster.initial_clients.values())
 
-        # initialize pointers and trackers
-        self.current_client = None
+        self._init_round_trackers()
+
+    def _init_round_trackers(self):
         self.round_start = None
         self.rounds_completed = 0
 
     def __iter__(self):
         """Restarts the `rounds` tracker, and updates active clients."""
-        self.round_start = None
-        self.rounds_completed = 0
+        self._init_round_trackers()
         self.cluster._prune_penalty_box()
 
         return self

--- a/tests/fluster/test_cluster.py
+++ b/tests/fluster/test_cluster.py
@@ -33,6 +33,8 @@ class FlusterClusterTests(unittest.TestCase):
         self.cluster = FlusterCluster([i.conn for i in self.instances],
                                       penalty_box_min_wait=0.5)
         self.keys = ['hi', 'redis', 'test']  # hashes to 3 separate values
+        self.requester1 = "hashablething"
+        self.requester2 = "anotherhashablething"
 
     def tearDown(self):
         for instance in self.instances:
@@ -97,30 +99,28 @@ class FlusterClusterTests(unittest.TestCase):
             self.instances[0] = RedisInstance(10101)
 
     def test_cycle_clients(self):
-        requester1 = "hashablething"
-        requester2 = "anotherhashablething"
         # should cycle through clients the given number of times
         desired_cycles = 2
         counter = 0
         returned_clients = set()
-        for client in self.cluster.get_client_cycle(requester1, cycles=desired_cycles):
+        for client in self.cluster.get_client_cycle(self.requester1, cycles=desired_cycles):
             counter += 1
             returned_clients.update([client])
 
         assert counter == (desired_cycles * len(self.cluster.active_clients))
         assert len(returned_clients) == len(self.cluster.active_clients)
 
+    def test_cycle_clients_with_failures(self):
         # should not include inactive nodes
         self.instances[0].terminate()
 
         counter = 0
-        key = 'silly'
-        for client in self.cluster.get_client_cycle(requester1):
+        for client in self.cluster.get_client_cycle(self.requester1):
             try:
-                client.incr(key, 1)
+                client.incr('key', 1)
                 counter += 1
             except:
-                continue  # handled by the cluster
+                continue  # exception handled by the cluster
 
         # Restart instance
         self.instances[0] = RedisInstance(10101)
@@ -132,21 +132,22 @@ class FlusterClusterTests(unittest.TestCase):
 
         # should add restarted nodes back to the list after reported failure
         counter = 0
-        for client in self.cluster.get_client_cycle(requester1):
-            client.incr(key, 1)
+        for client in self.cluster.get_client_cycle(self.requester1):
+            client.incr('key', 1)
             counter += 1
 
         assert counter == len(self.cluster.active_clients)
         assert counter == 3  # to verify it added the node back
 
+    def test_cycle_clients_tracking(self):
         # should track separate cycle entry points for each requester
         client1 = client2 = None
-        for counter, client in enumerate(self.cluster.get_client_cycle(requester1)):
+        for counter, client in enumerate(self.cluster.get_client_cycle(self.requester1)):
             if counter == 0:
                 client1 = client
                 break
 
-        for counter, client in enumerate(self.cluster.get_client_cycle(requester2)):
+        for counter, client in enumerate(self.cluster.get_client_cycle(self.requester2)):
             if counter == 0:
                 # make sure it counts from the beginning
                 assert client == client1
@@ -154,12 +155,11 @@ class FlusterClusterTests(unittest.TestCase):
             elif counter == 1:
                 client2 = client
 
-        # requester1 should pick up where it left off
-        for counter, client in enumerate(self.cluster.get_client_cycle(requester1)):
+        # self.requester1 should pick up where it left off
+        for counter, client in enumerate(self.cluster.get_client_cycle(self.requester1)):
             if counter == 0:
                 assert client == client2
                 break
-
 
     def test_zrevrange(self):
         """Add a sorted set, turn off the client, add to the set,

--- a/tests/fluster/test_cluster.py
+++ b/tests/fluster/test_cluster.py
@@ -227,7 +227,7 @@ class FlusterClusterTests(unittest.TestCase):
         key = 'foo'
         for element, count in zip(self.keys, (1.0, 2.0, 3.0)):
             client = self.cluster.get_client(element)
-            client.zadd(key, count, element)
+            client.zadd(key, {element: count})
         revrange = self.cluster.zrevrange_with_int_score(key, '+inf', 2)
         self.assertEqual(set([3, 2]), set(revrange.values()))
 
@@ -238,12 +238,12 @@ class FlusterClusterTests(unittest.TestCase):
         new_count = 5
         client = self.cluster.get_client(dropped_element)
         try:
-            client.zadd(key, new_count, dropped_element)
+            client.zadd(key, {dropped_element: new_count})
             raise Exception("Should not get here, client was terminated")
         except ConnectionError:
             client = self.cluster.get_client(dropped_element)
             print('replaced client', client)
-            client.zadd(key, new_count, dropped_element)
+            client.zadd(key, {dropped_element: new_count})
         revrange = self.cluster.zrevrange_with_int_score(key, '+inf', 2)
         self.assertEqual(set([new_count, 2]), set(revrange.values()))
 
@@ -255,6 +255,6 @@ class FlusterClusterTests(unittest.TestCase):
         self.assertEqual(set([new_count, 2]), set(revrange.values())) #restarted instance is empty in this case
 
         client = self.cluster.get_client(dropped_element)
-        client.zadd(key, 3, dropped_element) #put original value back in
+        client.zadd(key, {dropped_element: 3}) #put original value back in
         revrange = self.cluster.zrevrange_with_int_score(key, '+inf', 2)
         self.assertEqual(set([new_count, 2]), set(revrange.values())) #max value found for duplicates is returned

--- a/tests/fluster/test_cluster.py
+++ b/tests/fluster/test_cluster.py
@@ -154,7 +154,7 @@ class FlusterClusterTests(unittest.TestCase):
         # long-running iterations should still add connections back to the cluster
         drop_client = 3
         restart_client = 10
-        client_available = restart_client + (2 * 3)
+        client_available = restart_client + 1
 
         for idx, client in enumerate(self.cluster):
             # attempt to use each client
@@ -167,7 +167,7 @@ class FlusterClusterTests(unittest.TestCase):
                 self.instances[0].terminate()
             elif idx == restart_client:
                 self.instances[0] = RedisInstance(10101)
-            # client should be visible after the next _tick
+            # client should be visible after calling next() again
             elif idx == client_available:
                 assert len(self.cluster.active_clients) == 3
                 break

--- a/tests/fluster/test_cluster.py
+++ b/tests/fluster/test_cluster.py
@@ -7,7 +7,8 @@ import sys
 from redis.exceptions import ConnectionError
 from testinstances import RedisInstance
 
-from fluster import FlusterCluster
+from fluster import FlusterCluster, ClusterEmptyError
+import redis
 
 
 class FlusterClusterTests(unittest.TestCase):
@@ -95,6 +96,129 @@ class FlusterClusterTests(unittest.TestCase):
         finally:
             # Bring it back up
             self.instances[0] = RedisInstance(10101)
+
+    def test_cycle_clients(self):
+        # should cycle through clients indefinately
+        returned_clients = set()
+        limit = 15
+
+        assert True
+
+        for idx, client in enumerate(self.cluster):
+            returned_clients.update([client])
+            assert client is not None
+            if idx >= limit:
+                break
+
+        assert idx == 15
+        assert len(returned_clients) == len(self.cluster.active_clients)
+
+    def test_cycle_clients_with_failures(self):
+        # should not include inactive nodes
+        self.instances[0].terminate()
+        limit = 6
+        counter = 0
+
+        for idx, client in enumerate(self.cluster):
+            assert client is not None
+            try:
+                client.incr('key', 1)
+                counter += 1
+            except Exception as e:
+                print("oops", client, e)
+                continue  # exception handled by the cluster
+            if idx >= limit:
+                break
+
+        # Restart instance
+        self.instances[0] = RedisInstance(10101)
+        time.sleep(0.5)
+
+        assert counter == 6  # able to continue even when node is down
+        assert 2 == len(self.cluster.active_clients)
+        assert 2 == len(self.cluster.initial_clients.values()) - 1
+
+        # should add restarted nodes back to the list after reported failure
+        # calling __iter__ again checks the penalty box
+        counter = 0
+        for idx, client in enumerate(self.cluster):
+            if idx >= limit:
+                break
+            client.incr('key', 1)
+            counter += 1
+
+        assert counter == limit
+        assert len(self.cluster.active_clients) == 3  # to verify it added the node back
+
+    def test_long_running_iterations(self):
+        # long-running iterations should still add connections back to the cluster
+        drop_client = 3
+        restart_client = 10
+        client_available = restart_client + (2 * 3)
+
+        for idx, client in enumerate(self.cluster):
+            # attempt to use each client
+            try:
+                client.incr('key', 1)
+            except Exception:
+                continue  # exception handled by the cluster
+            # mimic connection dropping out and returning
+            if idx == drop_client:
+                self.instances[0].terminate()
+            elif idx == restart_client:
+                self.instances[0] = RedisInstance(10101)
+            # client should be visible after the next _tick
+            elif idx == client_available:
+                assert len(self.cluster.active_clients) == 3
+                break
+
+    def test_cycle_clients_tracking(self):
+        # should track separate cycle entry points for each instance
+        cluster_instance_1 = self.cluster
+        # connect to already-running testinstances, instead of making more,
+        # to mimic two FlusterCluster instances
+        redis_clients = [redis.StrictRedis(port=conn.port)
+                         for conn in self.instances]
+        cluster_instance_2 = FlusterCluster([i for i in redis_clients],
+                                            penalty_box_min_wait=0.5)
+
+        # advance cluster instance one
+        next(cluster_instance_1)
+
+        # should not start at the same point
+        assert next(cluster_instance_1) != next(cluster_instance_2)
+
+        for temp_conn in redis_clients:
+            del temp_conn
+
+    def test_dropped_connections_while_iterating(self):
+        # dropped connections in the middle of an iteration should not cause an infinite loop
+        # and should raise an exception
+        limit = 21
+
+        assert len(self.cluster.active_clients) == 3
+
+        drop_at_idx = (5, 6, 7)  # at these points, kill a connection
+        killed = 0
+        with self.assertRaises(ClusterEmptyError) as context:
+            for idx, client in enumerate(self.cluster):
+                if idx >= limit:
+                    break  # in case the test fails to stop
+                if idx in drop_at_idx:
+                    self.instances[killed].terminate()
+                    killed += 1
+                    print('killed ', idx, killed)
+                try:
+                    client.incr('key', 1)
+                except:
+                    pass  # mimic err handling
+            self.assertTrue('All clients are down.' in str(context.exception))
+
+        assert idx == 8  # the next iteration after the last client was killed
+
+        # restart all the instances
+        for instance, port in enumerate(range(10101, 10104)):
+            self.instances[instance] = RedisInstance(port)
 
     def test_zrevrange(self):
         """Add a sorted set, turn off the client, add to the set,

--- a/tests/fluster/test_utils.py
+++ b/tests/fluster/test_utils.py
@@ -141,7 +141,7 @@ class FlusterClusterTests(unittest.TestCase):
         for idx, item in enumerate(round_controlled(lis, rounds=desired_rounds)):
             pass
 
-        assert idx == desired_rounds * len(repeated_sublist)
+        assert idx == desired_rounds * len(repeated_sublist) - 1
 
         # more specific application
         active_cycle = self.cluster.get_active_client_cycle()
@@ -151,4 +151,4 @@ class FlusterClusterTests(unittest.TestCase):
             pass
 
         # should raise stopiteration at appropriate time
-        assert idx == (desired_rounds * len(self.cluster.active_clients)) - 1
+        assert idx == (desired_rounds * len(self.cluster.active_clients) - 1)

--- a/tests/fluster/test_utils.py
+++ b/tests/fluster/test_utils.py
@@ -1,0 +1,99 @@
+from __future__ import absolute_import, print_function
+import time
+import unittest
+import sys
+
+from testinstances import RedisInstance
+
+from fluster import FlusterCluster
+
+
+class FlusterClusterTests(unittest.TestCase):
+
+    def assertCountEqual(self, a, b):
+        if sys.version_info > (3, 0):
+            super(FlusterClusterTests, self).assertCountEqual(a, b)
+        else:
+            self.assertItemsEqual(a, b)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.instances = [RedisInstance(10101),
+                         RedisInstance(10102),
+                         RedisInstance(10103)]
+
+    @classmethod
+    def tearDownClass(cls):
+        for instance in cls.instances:
+            instance.terminate()
+
+    def setUp(self):
+        self.cluster = FlusterCluster([i.conn for i in self.instances],
+                                      penalty_box_min_wait=0.5)
+        self.keys = ['hi', 'redis', 'test']  # hashes to 3 separate values
+
+    def tearDown(self):
+        for instance in self.instances:
+            if hasattr(instance.conn, 'pool_id'):
+                delattr(instance.conn, 'pool_id')
+
+    def test_cycle_clients(self):
+        # should cycle through clients the given number of times
+        desired_rounds = 2
+        returned_clients = set()
+        active_clients_cycle = self.cluster.get_active_client_cycle(rounds=desired_rounds)
+
+        assert True
+
+        for idx, client in enumerate(active_clients_cycle):
+            returned_clients.update([client])
+            assert client is not None
+
+        assert (idx + 1) == (desired_rounds * len(self.cluster.active_clients))
+        assert len(returned_clients) == len(self.cluster.active_clients)
+
+    def test_cycle_clients_with_failures(self):
+        # should not include inactive nodes
+        self.instances[0].terminate()
+
+        desired_rounds = 2
+        counter = 0
+        active_clients_cycle = self.cluster.get_active_client_cycle(rounds=desired_rounds)
+
+        for client in active_clients_cycle:
+            assert client is not None
+            try:
+                client.incr('key', 1)
+                counter += 1
+            except Exception as e:
+                print("oops", client, e)
+                continue  # exception handled by the cluster
+
+        # Restart instance
+        self.instances[0] = RedisInstance(10101)
+        time.sleep(0.5)
+
+        assert counter == 4  # 2 rounds, 2 working clients each round
+        assert 2 == len(self.cluster.active_clients)
+        assert 2 == len(self.cluster.initial_clients.values()) - 1
+
+        # should add restarted nodes back to the list after reported failure
+        # calling __iter__ again checks the penalty box
+        counter = 0
+        for client in active_clients_cycle:
+            client.incr('key', 1)
+            counter += 1
+
+        assert counter == len(self.cluster.active_clients) * desired_rounds
+        assert len(self.cluster.active_clients) == 3  # to verify it added the node back
+
+    def test_cycle_clients_tracking(self):
+        # should track separate cycle entry points for each instance
+        active_cycle_1 = self.cluster.get_active_client_cycle(rounds=1)
+        active_cycle_2 = self.cluster.get_active_client_cycle(rounds=1)
+
+        # advance cycle 1
+        next(active_cycle_1)
+
+        # should not start at the same point
+        assert next(active_cycle_1) != next(active_cycle_2)

--- a/tests/fluster/test_utils.py
+++ b/tests/fluster/test_utils.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import, print_function
-import time
 import unittest
 import sys
 
 from testinstances import RedisInstance
-from fluster import FlusterCluster, ClusterEmptyError, round_controlled
-import redis
+from fluster import FlusterCluster, round_controlled
 
 
 class FlusterClusterTests(unittest.TestCase):
@@ -35,107 +33,6 @@ class FlusterClusterTests(unittest.TestCase):
         for instance in self.instances:
             if hasattr(instance.conn, 'pool_id'):
                 delattr(instance.conn, 'pool_id')
-
-    def test_cycle_clients(self):
-        # should cycle through clients indefinately
-        returned_clients = set()
-        limit = 15
-
-        assert True
-
-        for idx, client in enumerate(self.cluster):
-            returned_clients.update([client])
-            assert client is not None
-            if idx >= limit:
-                break
-
-        assert idx == 15
-        assert len(returned_clients) == len(self.cluster.active_clients)
-
-    def test_cycle_clients_with_failures(self):
-        # should not include inactive nodes
-        self.instances[0].terminate()
-        limit = 6
-        counter = 0
-
-        for idx, client in enumerate(self.cluster):
-            assert client is not None
-            try:
-                client.incr('key', 1)
-                counter += 1
-            except Exception as e:
-                print("oops", client, e)
-                continue  # exception handled by the cluster
-            if idx >= limit:
-                break
-
-        # Restart instance
-        self.instances[0] = RedisInstance(10101)
-        time.sleep(0.5)
-
-        assert counter == 6  # able to continue even when node is down
-        assert 2 == len(self.cluster.active_clients)
-        assert 2 == len(self.cluster.initial_clients.values()) - 1
-
-        # should add restarted nodes back to the list after reported failure
-        # calling __iter__ again checks the penalty box
-        counter = 0
-        for idx, client in enumerate(self.cluster):
-            if idx >= limit:
-                break
-            client.incr('key', 1)
-            counter += 1
-
-        assert counter == limit
-        assert len(self.cluster.active_clients) == 3  # to verify it added the node back
-
-    def test_cycle_clients_tracking(self):
-        # should track separate cycle entry points for each instance
-        cluster_instance_1 = self.cluster
-        # connect to already-running testinstances, instead of making more,
-        # to mimic two FlusterCluster instances
-        redis_clients = [redis.StrictRedis(port=conn.port)
-                         for conn in self.instances]
-        cluster_instance_2 = FlusterCluster([i for i in redis_clients],
-                                            penalty_box_min_wait=0.5)
-
-        # advance cluster instance one
-        next(cluster_instance_1)
-
-        # should not start at the same point
-        assert next(cluster_instance_1) != next(cluster_instance_2)
-
-        for temp_conn in redis_clients:
-            del temp_conn
-
-    def test_dropped_connections_while_iterating(self):
-        # dropped connections in the middle of an iteration should not cause an infinite loop
-        # and should raise an exception
-        limit = 21
-
-        assert len(self.cluster.active_clients) == 3
-
-        drop_at_idx = (5, 6, 7)  # at these points, kill a connection
-        killed = 0
-        with self.assertRaises(ClusterEmptyError) as context:
-            for idx, client in enumerate(self.cluster):
-                if idx >= limit:
-                    break  # in case the test fails to stop
-                if idx in drop_at_idx:
-                    self.instances[killed].terminate()
-                    killed += 1
-                    print('killed ', idx, killed)
-                try:
-                    client.incr('key', 1)
-                except:
-                    pass  # mimic err handling
-            self.assertTrue('All clients are down.' in str(context.exception))
-
-        assert idx == 8  # the next iteration after the last client was killed
-
-        # restart all the instances
-        for instance, port in enumerate(range(10101, 10104)):
-            self.instances[instance] = RedisInstance(port)
 
     def test_round_controller(self):
         # the round controller should track rounds and limit iterations


### PR DESCRIPTION
Some users of the cluster need the ability to cycle evenly through active connections, without a hashing mechanism available (as used in `get_client`). 

This PR adds a method that tracks a separate `itertools.cycle` for each requester, automatically handles penalty box maintenance, and will only return connections known to be active. It also allows the caller to specify how many times they are willing to cycle through the set of clients before continuing. This also removes the responsibility of the caller to check whether a client is active, penalize it, or otherwise track which client they saw last.

A few other methods were extracted from current functionality.